### PR TITLE
Import sys in whapa-gui.py script

### DIFF
--- a/whapa-gui.py
+++ b/whapa-gui.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import webbrowser
 from libs import update


### PR DESCRIPTION
Add `import sys` line to prevent error when executing `if sys.platform == "win32" or sys.platform == "win64" or sys.platform == "cygwin":` line