### PR TITLE
--s_databases Not Working Correctly

### DIFF
--- a/libs/whagodri.py
+++ b/libs/whagodri.py
@@ -705,7 +705,7 @@ if __name__ == "__main__":
                         filter_file: dict = {}
                         for file in wa_backup.backup_files(backup):
                             i = os.path.splitext(file["name"])[1]
-                            if "crypt" in i:
+                            if "crypt" in i and "mcrypt" not in i:
                                 filter_file[file["name"]] = int(file["sizeBytes"])
 
                         if args.no_parallel:


### PR DESCRIPTION
Hi,

just found out that apparently media files are now named .mcrypt1 (with E2E enabled) which make --s_databases sync everything, not just the databases.