### PR TITLE
packaging added might be necessary for whagodri

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,3 +9,4 @@ webdriver-manager
 selenium-stealth
 ConfigObj
 pycryptodome
+packaging


### PR DESCRIPTION
Hi I had this issue, where I wanted to use WhaGoDri.
Well turns out that packaging is required but not in the requirements.txt

I recommend adding it.

name = "packaging"