### PR TITLE
Bump gpsoauth to latest commit

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 requests
 colorama
-gpsoauth
+gpsoauth @ git+https://github.com/simon-weber/gpsoauth@b22c57a
 pyicloud
 pandas
 numpy


### PR DESCRIPTION
The gpsoauth repo contains vital fixes to let it (and then whagodri) work, but these fixes are not released on pypi ATTW.

I didn't test anything apart from whagodri. In general, pinning dependencies is a good idea.