### PR TITLE
whagodri: fix file skipping

### DIFF
--- a/libs/whagodri.py
+++ b/libs/whagodri.py
@@ -434,8 +434,7 @@ def get_multiple_files_with_out_threads(files_dict: dict, is_dry_run: bool):
     for file_url, file_size in files_dict.items():
         file_name = os.path.sep.join(file_url.split("/")[3:])
         local_file_path = (output_folder + "/" + file_name).replace("/", os.path.sep)
-        if os.path.isfile(local_file_path) and os.path.getsize(local_file_path) == file_size\
-                and os.path.isfile(local_file_path + "-metadata"):
+        if os.path.isfile(local_file_path) and os.path.getsize(local_file_path) == file_size:
             print("    [-] Number: {}/{} - {} : Already Exists".format(file_index, total_files, local_file_path))
 
         else:


### PR DESCRIPTION
As explained here https://github.com/B16f00t/whapa/commit/2603da6032abe5154392d7d713d408823168386e#r136704274 , whagodri will always redownload files with -np