### PR TITLE
Fixed command injection vulnerability within report function

### DIFF
--- a/whapa-gui.py
+++ b/whapa-gui.py
@@ -784,7 +784,8 @@ To export chats on an iOS phone, here are the steps:
             return
 
         if system == "Linux":
-            os.system('xdg-open "{}"'.format(self.path))
+            #os.system('xdg-open "{}"'.format(self.path)) # Unsafe, leads to command injection
+            subprocess.run(["xdg-open", self.path], check=True)
         else:
             os.startfile(self.path)
 


### PR DESCRIPTION
This PR fixes a command injection vulnerability within the report() function. 

Vulnerability information:
When opening HTML reports within Whapa, a specially crafted filename could be used to gain command injection on Linux systems due to how the filename is immediately passed to `os.system(xdg-open <filename>)` without sanitization.

## Proof of Concept
A specially crafted filename can be created via the following command: `touch 'report"; touch exploit.txt; ".html'`. Then within Whapa, select *Open Report* & open up the file we just created. After erroring out, our `exploit.txt` file will then be created.