### PR TITLE
Fix OAuth authentication

### DIFF
--- a/libs/gpsoauth/__init__.py
+++ b/libs/gpsoauth/__init__.py
@@ -197,6 +197,60 @@ def perform_master_login_oauth(
     return _perform_auth_request(data, proxy)
 
 
+def exchange_token(
+    email: str,
+    token: str,
+    android_id: str,
+    service: str = "ac2dm",
+    device_country: str = "us",
+    operator_country: str = "us",
+    lang: str = "en",
+    sdk_version: int = 17,
+    proxy: MutableMapping[str, str] | None = None,
+    client_sig: str = "38918a453d07199354f8b19af05ec6562ced5788",
+) -> dict[str, str]:
+    """
+    Exchanges a web oauth_token for a master token.
+
+    Return a dict, eg::
+        {
+            'Auth': '...',
+            'Email': 'email@gmail.com',
+            'GooglePlusUpgrade': '1',
+            'LSID': '...',
+            'PicasaUser': 'My Name',
+            'RopRevision': '1',
+            'RopText': ' ',
+            'SID': '...',
+            'Token': 'oauth2rt_1/...',
+            'firstName': 'My',
+            'lastName': 'Name',
+            'services': 'hist,mail,googleme,...'
+        }
+    """
+
+    data: dict[str, int | str | bytes] = {
+        "accountType": "HOSTED_OR_GOOGLE",
+        "Email": email,
+        "has_permission": 1,
+        "add_account": 1,
+        "ACCESS_TOKEN": 1,
+        "Token": token,
+        "service": service,
+        "source": "android",
+        "androidId": android_id,
+        "device_country": device_country,
+        "operatorCountry": operator_country,
+        "lang": lang,
+        "sdk_version": sdk_version,
+        "client_sig": client_sig,
+        "callerSig": client_sig,
+        "droidguard_results": "dummy123",
+    }
+
+    return _perform_auth_request(data, proxy)
+
+
 def perform_oauth(
     email: str,
     master_token: str,

--- a/libs/gpsoauth/__init__.py
+++ b/libs/gpsoauth/__init__.py
@@ -14,6 +14,13 @@ from . import google
 
 __version__ = version(__package__)
 
+SSL_DEFAULT_CIPHERS = None
+if version("urllib3") < "2.0.0a1":
+    # pylint: disable-next=no-name-in-module
+    from urllib3.util.ssl_ import DEFAULT_CIPHERS
+
+    SSL_DEFAULT_CIPHERS = DEFAULT_CIPHERS
+
 # The key is distirbuted with Google Play Services.
 # This one is from version 7.3.29.
 B64_KEY_7_3_29 = (
@@ -63,7 +70,8 @@ class AuthHTTPAdapter(requests.adapters.HTTPAdapter):
         Authentication.
         """
         context = SSLContext()
-        context.set_ciphers(ssl_.DEFAULT_CIPHERS)
+        if SSL_DEFAULT_CIPHERS:
+            context.set_ciphers(SSL_DEFAULT_CIPHERS)
         context.verify_mode = ssl.CERT_REQUIRED
         context.options &= ~ssl_.OP_NO_TICKET
         self.poolmanager = PoolManager(*args, ssl_context=context, **kwargs)

--- a/libs/whagodri.py
+++ b/libs/whagodri.py
@@ -38,7 +38,17 @@ class WaBackup:
     """
 
     def __init__(self, gmail, password, android_id, celnumbr, oauth_token):
-        if not oauth_token:
+        master_token = None
+        if oauth_token:
+            print("Exchanging web oauth_token to master token...")
+            token = gpsoauth.exchange_token(gmail, oauth_token, android_id)
+            if "Token" in token:
+                print("Granted.")
+                master_token = token['Token']
+            else:
+                error(token)
+                quit()
+        else:
             print("Requesting access to Google...")
             token = gpsoauth.perform_master_login(email=gmail, password=password, android_id=android_id)
             if token.get("Error") == "NeedsBrowser":
@@ -116,10 +126,14 @@ class WaBackup:
                     print("Granted.")
                     oauth_token = token['Token']
 
+            # This password auth logic is wrong and needs fixing
+            # But for now let's just do it like it was previously
+            master_token = oauth_token
+
         print("Requesting authentication for Google Drive...")
         auth = gpsoauth.perform_oauth(
             gmail,
-            oauth_token,
+            master_token,
             android_id,
             "oauth2:https://www.googleapis.com/auth/drive.appdata",
             "com.whatsapp",


### PR DESCRIPTION
Currently OAuth authentication is broken.

You will always get `{'Error': 'Unknown'}`

This PR fixes that.
See https://github.com/simon-weber/gpsoauth?tab=readme-ov-file#alternative-flow

This PR also backports these:
* https://github.com/simon-weber/gpsoauth/commit/a4cad3a9744b36d9aa272719ae2a701ffee8dfd5
* https://github.com/simon-weber/gpsoauth/commit/8a5212481f80312e06ba6e0a29fbcfca1f210fd1

`gpsoauth.perform_oauth()` needs `master token` and not OAuth token.


Password authentication / `perform_master_login()` is also broken as I couldn't get it to work so I'm not fixing it and leaving it as is (broken).

If someone figures that out then you should drop included `gpsoauth` and just use upstream https://github.com/simon-weber/gpsoauth
